### PR TITLE
adding badge for Codacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Baudit
 
 [![Build Status](https://travis-ci.org/CMPUT301F18T16/Baudit.svg?branch=master)](https://travis-ci.org/CMPUT301F18T16/Baudit)
-
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/5fc2b184b7ca4f1690561667314c45fb)](https://www.codacy.com/app/nklapste/Baudit?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CMPUT301F18T16/Baudit&amp;utm_campaign=Badge_Grade)
 
 [Click here](https://cmput301f18t16.github.io/Baudit/) to view Baudit's 
 JavaDoc documentation 


### PR DESCRIPTION
Adding a badge noting the status of Codacy within the main `README.md`.

The service can be checked out at:
https://app.codacy.com