### PR TITLE
adding badge for CodeFactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Baudit
 
 [![Build Status](https://travis-ci.org/CMPUT301F18T16/Baudit.svg?branch=master)](https://travis-ci.org/CMPUT301F18T16/Baudit)
-
+[![CodeFactor](https://www.codefactor.io/repository/github/cmput301f18t16/baudit/badge)](https://www.codefactor.io/repository/github/cmput301f18t16/baudit)
 
 [Click here](https://cmput301f18t16.github.io/Baudit/) to view Baudit's 
 JavaDoc documentation 


### PR DESCRIPTION
Adding a badge noting the status of CodeFactor within the main `README.md`.

The service can be checked out at:
https://www.codefactor.io