### PR TITLE
Feature/RecordPhoto

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     androidTestImplementation "com.android.support.test.espresso:espresso-intents:3.0.2"
     // Required for local unit tests (JUnit 4 framework)
     testImplementation 'junit:junit:4.12'
+    // Optional -- Mockito framework
+    testImplementation 'org.mockito:mockito-core:1.10.19'
     // Elastic Search
     implementation 'io.searchbox:jest-droid:2.0.0'
     // robotium gui tests

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation "com.android.support.test.espresso:espresso-intents:3.0.2"
     // Required for local unit tests (JUnit 4 framework)
     testImplementation 'junit:junit:4.12'
-    // Optional -- Mockito framework
+    // Mockito framework
     testImplementation 'org.mockito:mockito-core:1.10.19'
     // Elastic Search
     implementation 'io.searchbox:jest-droid:2.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // Required for local unit tests (JUnit 4 framework)
     testImplementation 'junit:junit:4.12'
     // Mockito framework
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
     // Elastic Search
     implementation 'io.searchbox:jest-droid:2.0.0'
     // robotium gui tests

--- a/app/src/main/java/ca/klapstein/baudit/data/RecordPhoto.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/RecordPhoto.java
@@ -5,13 +5,34 @@ import android.graphics.Bitmap;
 public class RecordPhoto implements Photo {
     private static final String TAG = "RecordPhoto";
 
-    @Override
-    public Bitmap getBitmap() {
-        return null;
+    private Bitmap bitmap;
+
+    public RecordPhoto(Bitmap bitmap) throws IllegalArgumentException {
+        this.setBitmap(bitmap);
+    }
+
+    /**
+     * Check if a given {@code Bitmap} image is valid for usage as a {@code RecordPhoto}.
+     *
+     * @param bitmap {@code Bitmap} the Bitmap image to validate
+     * @return {@code boolean} {@code true} if the {@code Bitmap} is valid, otherwise {@code false}
+     */
+    static public boolean isValid(Bitmap bitmap) {
+        // TODO: implement
+        return true;
     }
 
     @Override
-    public void setBitmap(Bitmap bitmap) {
+    public Bitmap getBitmap() {
+        return bitmap;
+    }
 
+    @Override
+    public void setBitmap(Bitmap bitmap) throws IllegalArgumentException {
+        if (!isValid(bitmap)) {
+            throw new IllegalArgumentException("invalid bitmap for RecordPhoto");
+        } else {
+            this.bitmap = bitmap;
+        }
     }
 }

--- a/app/src/main/java/ca/klapstein/baudit/data/RecordPhoto.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/RecordPhoto.java
@@ -2,6 +2,13 @@ package ca.klapstein.baudit.data;
 
 import android.graphics.Bitmap;
 
+/**
+ * Data class representing a {@code Record}'s photo.
+ * <p>
+ * A {@code Record} can optionally have a {@code RecordPhoto}.
+ *
+ * @see Record
+ */
 public class RecordPhoto implements Photo {
     private static final String TAG = "RecordPhoto";
 

--- a/app/src/test/java/ca/klapstein/baudit/data/RecordPhotoTest.java
+++ b/app/src/test/java/ca/klapstein/baudit/data/RecordPhotoTest.java
@@ -1,21 +1,84 @@
 package ca.klapstein.baudit.data;
 
+import android.graphics.Bitmap;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mock;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@code RecordPhoto}.
+ * <p>
+ * NOTE: it may be smarted to just make this an instrumentation test as it
+ * requires android utilities to actually work. For now using mocks is reasonable but
+ * testing the validator might become problematic.
+ */
 public class RecordPhotoTest {
+
+    @Mock
+    private Bitmap mockValidBitmap;
+
+    @Mock
+    private Bitmap mockInvalidBitmap;
 
     @Before
     public void setUp() {
+        mockValidBitmap = mock(Bitmap.class);
+        mockInvalidBitmap = mock(Bitmap.class);
     }
 
     @After
     public void tearDown() {
+        mockValidBitmap = null;
     }
 
     @Test
-    public void testStub() {
-        // TODO: write tests
+    public void constructionValid() {
+        RecordPhoto recordPhoto = new RecordPhoto(mockValidBitmap);
+        assertNotNull(recordPhoto);
+    }
+
+    @Test
+    public void getBitMap() {
+        RecordPhoto recordPhoto = new RecordPhoto(mockValidBitmap);
+        Bitmap bitmap = recordPhoto.getBitmap();
+        assertNotNull(bitmap);
+        assertEquals(mockValidBitmap, bitmap);
+    }
+
+    @Test
+    public void setBitMap() {
+        RecordPhoto recordPhoto = new RecordPhoto(mockValidBitmap);
+        recordPhoto.setBitmap(mockValidBitmap);
+        Bitmap bitmap = recordPhoto.getBitmap();
+        assertEquals(mockValidBitmap, bitmap);
+    }
+
+    @Test
+    public void isValid() {
+        assertTrue(RecordPhoto.isValid(mockValidBitmap));
+    }
+
+    @Ignore("RecordPhoto validation is not implemented")
+    @Test(expected = IllegalArgumentException.class)
+    public void constructionInvalid() {
+        new RecordPhoto(mockInvalidBitmap);
+    }
+
+    @Ignore("RecordPhoto validation is not implemented")
+    @Test(expected = IllegalArgumentException.class)
+    public void setBitMapInvalid() {
+        RecordPhoto recordPhoto = new RecordPhoto(mockValidBitmap);
+        recordPhoto.setBitmap(mockInvalidBitmap);
+    }
+
+    @Ignore("RecordPhoto validation is not implemented")
+    @Test
+    public void isValidInvalid() {
+        assertFalse(RecordPhoto.isValid(mockInvalidBitmap));
     }
 }


### PR DESCRIPTION
Adding some skeleton code for `RecordPhoto`.

Also adding tests for `RecordPhoto` utilizing mocking via `mockito`.

https://site.mockito.org/

**Note:** validation of `RecordPhoto` through the `RecordPhoto.isValid` method is not implemented
**Note:** tests for invalid `RecordPhoto`s are not yet implemented.
