### PR TITLE
Feature/unique id&login

### DIFF
--- a/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginCareProviderActivityTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginCareProviderActivityTest.java
@@ -57,8 +57,8 @@ public class LoginCareProviderActivityTest extends ActivityTestRule<LoginCarePro
      */
     @Test
     public void testLoginFail() {
-        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_username), "wrong");
-        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_password), "wrong");
+        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_username), "TESTCareProvider1");
+        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_password), "BADPASSWORD");
         solo.clickOnView(solo.getView(R.id.login_care_provider_button));
         solo.waitForText(getActivity().getResources().getString(R.string.login_failed));
         solo.assertCurrentActivity("Wrong Activity", LoginCareProviderActivity.class);

--- a/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginCareProviderActivityTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginCareProviderActivityTest.java
@@ -3,13 +3,11 @@ package ca.klapstein.baudit.activities;
 import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 import android.widget.EditText;
-
+import ca.klapstein.baudit.R;
 import com.robotium.solo.Solo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import ca.klapstein.baudit.R;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
@@ -46,8 +44,9 @@ public class LoginCareProviderActivityTest extends ActivityTestRule<LoginCarePro
      */
     @Test
     public void testLoginSuccess() {
-        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_username), "test");
-        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_password), "foo");
+        // TODO: add hook to ensure test care provider is added to the remote or make some mock
+        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_username), "TESTCareProvider1");
+        solo.enterText((EditText) solo.getView(R.id.enter_care_provider_password), "foobar123");
         solo.clickOnView(solo.getView(R.id.login_care_provider_button));
         solo.assertCurrentActivity("Wrong Activity", PatientListActivity.class);
     }

--- a/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginPatientActivityTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginPatientActivityTest.java
@@ -3,14 +3,11 @@ package ca.klapstein.baudit.activities;
 import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 import android.widget.EditText;
-
+import ca.klapstein.baudit.R;
 import com.robotium.solo.Solo;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import ca.klapstein.baudit.R;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
@@ -47,8 +44,9 @@ public class LoginPatientActivityTest extends ActivityTestRule<LoginPatientActiv
      */
     @Test
     public void testLoginSuccess() {
-        solo.enterText((EditText) solo.getView(R.id.enter_patient_username), "test");
-        solo.enterText((EditText) solo.getView(R.id.enter_patient_password), "foo");
+        // TODO: add hook to ensure test patient is added to the remote or make some mock
+        solo.enterText((EditText) solo.getView(R.id.enter_patient_username), "TESTPatient1");
+        solo.enterText((EditText) solo.getView(R.id.enter_patient_password), "foobar123");
         solo.clickOnView(solo.getView(R.id.login_patient_button));
         solo.assertCurrentActivity("Wrong Activity", PatientHomeActivity.class);
     }

--- a/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginPatientActivityTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/activities/LoginPatientActivityTest.java
@@ -57,8 +57,8 @@ public class LoginPatientActivityTest extends ActivityTestRule<LoginPatientActiv
      */
     @Test
     public void testLoginFail() {
-        solo.enterText((EditText) solo.getView(R.id.enter_patient_username), "wrong");
-        solo.enterText((EditText) solo.getView(R.id.enter_patient_password), "wrong");
+        solo.enterText((EditText) solo.getView(R.id.enter_patient_username), "TESTPatient1");
+        solo.enterText((EditText) solo.getView(R.id.enter_patient_password), "BADPASSWORD");
         solo.clickOnView(solo.getView(R.id.login_patient_button));
         solo.waitForText(getActivity().getResources().getString(R.string.login_failed));
         solo.assertCurrentActivity("Wrong Activity", LoginPatientActivity.class);

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/DataModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/DataModelTest.java
@@ -127,4 +127,34 @@ public class DataModelTest {
         assertNotNull(careProvider);
         assertEquals(new Username("TESTCareProvider1"), careProvider.getUsername());
     }
+
+    @Test
+    public void uniqueIDTrue() throws InterruptedException {
+        this.commitCareProvider();
+        // wait for remote elastic search cluster to settle
+        Thread.sleep(10000);
+        assertTrue(dataModel.uniqueID(new Username("UNIQUE_USERNAME")));
+    }
+
+    @Test
+    public void uniqueIDFalse() throws InterruptedException {
+        this.commitCareProvider();
+        // wait for remote elastic search cluster to settle
+        Thread.sleep(10000);
+        assertFalse(dataModel.uniqueID(new Username("TESTCareProvider2")));
+    }
+
+    @Test
+    public void validateLoginSuccess() throws InterruptedException {
+        this.commitPatient();
+        this.commitCareProvider();
+        Thread.sleep(10000);
+        assertTrue(dataModel.validateLogin(new Username("TESTPatient3"), new Password("foobar123")));
+        assertTrue(dataModel.validateLogin(new Username("TESTCareProvider1"), new Password("foobar123")));
+    }
+
+    @Test
+    public void validateLoginFail() {
+        assertFalse(dataModel.validateLogin(new Username("NONSUCH_ACCOUNT"), new Password("PASSWORD")));
+    }
 }

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
@@ -53,8 +53,8 @@ public class RemoteModelTest {
     @Test
     public void ValidateLoginInvalidUser() throws ExecutionException, InterruptedException {
         assertNull(new RemoteModel.ValidateLogin().execute(
-                new Username("NONSUCH_ACCOUNT").getUsernameString(),
-                new Password("BADPASSWORD").getPassword()).get());
+                new Username("NONSUCH_ACCOUNT").toString(),
+                new Password("BADPASSWORD").toString()).get());
     }
 
     @Test

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
@@ -1,13 +1,12 @@
 package ca.klapstein.baudit.models;
 
-import ca.klapstein.baudit.data.CareProvider;
-import ca.klapstein.baudit.data.Patient;
-import ca.klapstein.baudit.data.PatientTreeSet;
+import ca.klapstein.baudit.data.*;
 import org.junit.Test;
 
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -50,5 +49,18 @@ public class RemoteModelTest {
         new RemoteModel.AddCareProviderTask().execute(
                 new TreeSet<CareProvider>().toArray(new CareProvider[0])
         );
+    }
+
+    @Test
+    public void ValidateLoginInvalidUser() {
+        assertNull(new RemoteModel.ValidateLogin().execute(
+                new Username("NONSUCH_ACCOUNT").getUsernameString(),
+                new Password("NONSUCH_PASSWORD").getPassword()));
+    }
+
+    @Test
+    public void uniqueIDTrue() throws InterruptedException, ExecutionException {
+        // wait for remote elastic search cluster to settle
+        assertTrue(new RemoteModel.UniqueID().execute("NONSUCH_ACCOUNT").get());
     }
 }

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
@@ -55,7 +55,7 @@ public class RemoteModelTest {
     public void ValidateLoginInvalidUser() {
         assertNull(new RemoteModel.ValidateLogin().execute(
                 new Username("NONSUCH_ACCOUNT").getUsernameString(),
-                new Password("NONSUCH_PASSWORD").getPassword()));
+                new Password("BADPASSWORD").getPassword()));
     }
 
     @Test

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
@@ -51,10 +51,10 @@ public class RemoteModelTest {
     }
 
     @Test
-    public void ValidateLoginInvalidUser() {
+    public void ValidateLoginInvalidUser() throws ExecutionException, InterruptedException {
         assertNull(new RemoteModel.ValidateLogin().execute(
                 new Username("NONSUCH_ACCOUNT").getUsernameString(),
-                new Password("BADPASSWORD").getPassword()));
+                new Password("BADPASSWORD").getPassword()).get());
     }
 
     @Test

--- a/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
+++ b/app/src/androidTest/java/ca/klapstein/baudit/models/RemoteModelTest.java
@@ -7,8 +7,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 // TODO: coverage is provided by DataModelTest but we should still develop unit tests for this
 public class RemoteModelTest {
@@ -60,7 +59,13 @@ public class RemoteModelTest {
 
     @Test
     public void uniqueIDTrue() throws InterruptedException, ExecutionException {
-        // wait for remote elastic search cluster to settle
         assertTrue(new RemoteModel.UniqueID().execute("NONSUCH_ACCOUNT").get());
+    }
+
+    @Test
+    public void uniqueIDFalse() throws InterruptedException, ExecutionException {
+        // TODO: add hook to ensure the test account is added to the remote or make some mock
+        assertFalse(new RemoteModel.UniqueID().execute("TESTCareProvider1").get());
+        assertFalse(new RemoteModel.UniqueID().execute("TESTPatient1").get());
     }
 }

--- a/app/src/main/java/ca/klapstein/baudit/activities/LoginPatientActivity.java
+++ b/app/src/main/java/ca/klapstein/baudit/activities/LoginPatientActivity.java
@@ -7,7 +7,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
 import ca.klapstein.baudit.R;
 import ca.klapstein.baudit.presenters.LoginPresenter;
 import ca.klapstein.baudit.views.LoginView;
@@ -41,6 +40,7 @@ public class LoginPatientActivity extends AppCompatActivity implements LoginView
         passwordInput = findViewById(R.id.enter_patient_password);
 
         errorText = findViewById(R.id.patient_login_error_text);
+
         Button loginButton = findViewById(R.id.login_patient_button);
         loginButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/ca/klapstein/baudit/activities/LoginPatientActivity.java
+++ b/app/src/main/java/ca/klapstein/baudit/activities/LoginPatientActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+
 import ca.klapstein.baudit.R;
 import ca.klapstein.baudit.presenters.LoginPresenter;
 import ca.klapstein.baudit.views.LoginView;
@@ -40,7 +41,6 @@ public class LoginPatientActivity extends AppCompatActivity implements LoginView
         passwordInput = findViewById(R.id.enter_patient_password);
 
         errorText = findViewById(R.id.patient_login_error_text);
-
         Button loginButton = findViewById(R.id.login_patient_button);
         loginButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/ca/klapstein/baudit/data/Account.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Account.java
@@ -5,7 +5,7 @@ import android.support.annotation.NonNull;
 /**
  * Data class representing a basic account/account of Baudit.
  */
-public class Account {
+public class Account implements Comparable<Account> {
     private static final String TAG = "Account";
 
     public Account(@NonNull Username username, @NonNull ContactInfo contactInfo, @NonNull Password password) {
@@ -48,5 +48,11 @@ public class Account {
 
     public void setPassword(@NonNull Password password) {
         this.password = password;
+    }
+
+    @Override
+    public int compareTo(@NonNull Account account) {
+        return this.getUsername().toString()
+                .compareTo(account.getUsername().toString());
     }
 }

--- a/app/src/main/java/ca/klapstein/baudit/data/Account.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Account.java
@@ -3,9 +3,9 @@ package ca.klapstein.baudit.data;
 import android.support.annotation.NonNull;
 
 /**
- * Abstract class representing a basic account/account of Baudit.
+ * Data class representing a basic account/account of Baudit.
  */
-public abstract class Account {
+public class Account {
     private static final String TAG = "Account";
 
     public Account(@NonNull Username username, @NonNull ContactInfo contactInfo, @NonNull Password password) {

--- a/app/src/main/java/ca/klapstein/baudit/data/CareProvider.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/CareProvider.java
@@ -1,11 +1,9 @@
 package ca.klapstein.baudit.data;
 
-import android.support.annotation.NonNull;
-
 /**
  * Class that represents a Care Provider.
  */
-public class CareProvider extends Account implements Comparable<CareProvider> {
+public class CareProvider extends Account {
     private static final String TAG = "CareProvider";
 
     public CareProvider(Username username, ContactInfo contactInfo, Password password) {
@@ -19,14 +17,7 @@ public class CareProvider extends Account implements Comparable<CareProvider> {
         this.assignedPatientTreeSet = new PatientTreeSet();
     }
 
-    @Override
-    public int compareTo(@NonNull CareProvider careProvider) {
-        return this.getUsername().getUsernameString()
-                .compareTo(careProvider.getUsername().getUsernameString());
-    }
-
     public PatientTreeSet getAssignedPatientTreeSet(){
         return this.assignedPatientTreeSet;
     }
-
 }

--- a/app/src/main/java/ca/klapstein/baudit/data/Password.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Password.java
@@ -36,7 +36,8 @@ public class Password {
     }
 
     @NonNull
-    public String getPassword() {
+    @Override
+    public String toString() {
         return password;
     }
 

--- a/app/src/main/java/ca/klapstein/baudit/data/Patient.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Patient.java
@@ -1,11 +1,9 @@
 package ca.klapstein.baudit.data;
 
-import android.support.annotation.NonNull;
-
 /**
  * Class that represents a Patient.
  */
-public class Patient extends Account implements Comparable<Patient> {
+public class Patient extends Account {
 
     private ProblemTreeSet problemTreeSet;
   
@@ -19,12 +17,6 @@ public class Patient extends Account implements Comparable<Patient> {
         this.problemTreeSet = new ProblemTreeSet();
     }
 
-    @Override
-    public int compareTo(@NonNull Patient patient) {
-        return this.getUsername().getUsernameString()
-            .compareTo(patient.getUsername().getUsernameString());
-    }
-    
     /**
      * Get the list of {@code Problem}s owned by the {@code Patient}.
      *

--- a/app/src/main/java/ca/klapstein/baudit/data/Problem.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Problem.java
@@ -16,8 +16,6 @@ public class Problem implements Comparable<Problem> {
     private static final int MAX_DESCRIPTION_LENGTH = 300;
     private static final int MAX_TITLE_LENGTH = 30;
 
-    public static final String ES_TYPE = "problem";
-
     private String title;
     private String description;
     private Date date;

--- a/app/src/main/java/ca/klapstein/baudit/data/Problem.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Problem.java
@@ -103,11 +103,4 @@ public class Problem implements Comparable<Problem> {
             return getDate().compareTo(problem.getDate()); // Order by date
         }
     }
-
-    private String id;
-
-    public void setProblemID(String id) {
-        this.id = id;
-    }
-
 }

--- a/app/src/main/java/ca/klapstein/baudit/data/Username.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Username.java
@@ -12,7 +12,7 @@ public class Username {
     private String username;
 
     public Username(@NonNull String username) throws IllegalArgumentException {
-        this.setUsernameString(username);
+        this.setUsername(username);
     }
 
     /**
@@ -30,11 +30,12 @@ public class Username {
     }
 
     @NonNull
-    public String getUsernameString() {
+    @Override
+    public String toString() {
         return this.username;
     }
 
-    public void setUsernameString(@NonNull String username) throws IllegalArgumentException {
+    public void setUsername(@NonNull String username) throws IllegalArgumentException {
         if (!isValid(username)) {
             throw new IllegalArgumentException("Invalid username");
         } else {
@@ -45,7 +46,7 @@ public class Username {
     @Override
     public int hashCode() {
         int result = 17;
-        result = 31 * result + this.getUsernameString().hashCode();
+        result = 31 * result + this.toString().hashCode();
         return result;
     }
 
@@ -55,7 +56,7 @@ public class Username {
             return false;
         } else if (obj.getClass().equals(Username.class)) {
             Username otherUsername = (Username) obj;
-            return this.getUsernameString().equals(otherUsername.getUsernameString());
+            return this.toString().equals(otherUsername.toString());
         } else {
             return false;
         }

--- a/app/src/main/java/ca/klapstein/baudit/data/Username.java
+++ b/app/src/main/java/ca/klapstein/baudit/data/Username.java
@@ -1,7 +1,6 @@
 package ca.klapstein.baudit.data;
 
 import android.support.annotation.NonNull;
-import ca.klapstein.baudit.models.DataModel;
 
 /**
  * Data class representing a Baudit's {@code Account}'s username.
@@ -27,7 +26,7 @@ public class Username {
      */
     static public boolean isValid(String username) {
         int len = username.length();
-        return len >= 8 && len <= 20 && DataModel.uniqueID(username);
+        return len >= 8 && len <= 20;
     }
 
     @NonNull

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -168,7 +168,6 @@ public class DataModel {
      * @param careProvider {@code CareProvider}
      */
     public void commitCareProvider(CareProvider careProvider) {
-        // TODO: save to remote
         new RemoteModel.AddCareProviderTask().execute(careProvider);
         // save to local
         PreferencesModel.saveSharedPreferencesCareProvider(context, careProvider);

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -24,7 +24,7 @@ public class DataModel {
     }
 
     /**
-     * Validate whether a given {@code Username} is not already taken within both the local and remote.
+     * Validate whether a given {@code Username} is not already taken within the remote.
      *
      * @param username {@code Username}
      * @return {@code true} if the {@code Username} is not already taken, otherwise {@code false}

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -24,11 +24,10 @@ public class DataModel {
     }
 
     /**
-     * Validate whether a given username {@code String} representation is not already
-     * taken within both the local and remote.
+     * Validate whether a given {@code Username} is not already taken within both the local and remote.
      *
      * @param username {@code Username}
-     * @return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
+     * @return {@code true} if the {@code Username} is not already taken, otherwise {@code false}
      */
     public boolean uniqueID(Username username) {
         return getPatient(username) == null && getCareProvider(username) == null;
@@ -40,7 +39,6 @@ public class DataModel {
      * <p>
      * TODO: implement offline login method? Cookie/token based
      *
-     * considering param type {@code String}
      * @param username {@code Username}
      * @param password {@code Password}
      * @return {@code boolean}

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -37,8 +37,12 @@ public class DataModel {
      */
     static public boolean uniqueID(String username) {
         // TODO: validate from the local?
-        // TODO: implement from RemoteModel
-        return true;
+        try {
+            return new RemoteModel.uniqueID().execute(username).get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.e(TAG, "failure getting Patient from remote", e);
+            return false;
+        }
     }
 
     /**
@@ -47,14 +51,19 @@ public class DataModel {
      * <p>
      * TODO: implement
      *
+     * considering param type {@code String}
      * @param username {@code String}
      * @param password {@code String}
      * @return {@code boolean}
      */
-    public boolean validateLogin(String username, String password) {
-        // TODO: implement from RemoteModel
+    public Patient validateLogin(/*String type, */String username, String password) {
         // TODO: implement offline login method? Cookie/token based
-        return RemoteModel.validateLogin(username, password);
+        try {
+            return new RemoteModel.validateLogin().execute(/*type, */username, password).get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.e(TAG, "failure getting Patient from remote", e);
+            return null;
+        }
     }
 
     /**

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -3,10 +3,7 @@ package ca.klapstein.baudit.models;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.util.Log;
-import ca.klapstein.baudit.data.CareProvider;
-import ca.klapstein.baudit.data.Patient;
-import ca.klapstein.baudit.data.PatientTreeSet;
-import ca.klapstein.baudit.data.Username;
+import ca.klapstein.baudit.data.*;
 
 import java.util.concurrent.ExecutionException;
 
@@ -35,14 +32,8 @@ public class DataModel {
      * @param username {@code String}
      * @return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
      */
-    static public boolean uniqueID(String username) {
-        // TODO: validate from the local?
-        try {
-            return new RemoteModel.uniqueID().execute(username).get();
-        } catch (ExecutionException | InterruptedException e) {
-            Log.e(TAG, "failure getting Patient from remote", e);
-            return false;
-        }
+    public boolean uniqueID(Username username) {
+        return getPatient(username) == null && getCareProvider(username) == null;
     }
 
     /**
@@ -52,17 +43,19 @@ public class DataModel {
      * TODO: implement
      *
      * considering param type {@code String}
-     * @param username {@code String}
-     * @param password {@code String}
+     * @param username {@code Username}
+     * @param password {@code Password}
      * @return {@code boolean}
      */
-    public Patient validateLogin(/*String type, */String username, String password) {
+    public boolean validateLogin(Username username, Password password) {
+
         // TODO: implement offline login method? Cookie/token based
         try {
-            return new RemoteModel.validateLogin().execute(/*type, */username, password).get();
+            Account account = new RemoteModel.ValidateLogin().execute(username.getUsernameString(), password.getPassword()).get();
+            return account != null;
         } catch (ExecutionException | InterruptedException e) {
             Log.e(TAG, "failure getting Patient from remote", e);
-            return null;
+            return false;
         }
     }
 

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -26,8 +26,6 @@ public class DataModel {
     /**
      * Validate whether a given username {@code String} representation is not already
      * taken within both the local and remote.
-     * <p>
-     * TODO: implement
      *
      * @param username {@code Username}
      * @return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
@@ -40,7 +38,7 @@ public class DataModel {
      * Validate that a given username and password pair match to a valid user within the remote ElasticSearch.
      * Or validate that a local authentication token exists within the local.
      * <p>
-     * TODO: implement
+     * TODO: implement offline login method? Cookie/token based
      *
      * considering param type {@code String}
      * @param username {@code Username}
@@ -48,8 +46,6 @@ public class DataModel {
      * @return {@code boolean}
      */
     public boolean validateLogin(Username username, Password password) {
-
-        // TODO: implement offline login method? Cookie/token based
         try {
             Account account = new RemoteModel.ValidateLogin().execute(username.toString(), password.toString()).get();
             return account != null;

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -29,7 +29,7 @@ public class DataModel {
      * <p>
      * TODO: implement
      *
-     * @param username {@code String}
+     * @param username {@code Username}
      * @return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
      */
     public boolean uniqueID(Username username) {

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -51,7 +51,7 @@ public class DataModel {
 
         // TODO: implement offline login method? Cookie/token based
         try {
-            Account account = new RemoteModel.ValidateLogin().execute(username.getUsernameString(), password.getPassword()).get();
+            Account account = new RemoteModel.ValidateLogin().execute(username.toString(), password.toString()).get();
             return account != null;
         } catch (ExecutionException | InterruptedException e) {
             Log.e(TAG, "failure getting Patient from remote", e);
@@ -71,7 +71,7 @@ public class DataModel {
     public Patient getPatient(Username username) {
         // check remote
         try {
-            return new RemoteModel.GetPatient().execute(username.getUsernameString()).get();
+            return new RemoteModel.GetPatient().execute(username.toString()).get();
         } catch (ExecutionException | InterruptedException e) {
             Log.e(TAG, "failure getting Patient from remote", e);
         }
@@ -157,7 +157,7 @@ public class DataModel {
     public CareProvider getCareProvider(Username username) {
         // check remote
         try {
-            return new RemoteModel.GetCareProvider().execute(username.getUsernameString()).get();
+            return new RemoteModel.GetCareProvider().execute(username.toString()).get();
         } catch (ExecutionException | InterruptedException e) {
             Log.e(TAG, "failure getting CareProvider from remote", e);
         }

--- a/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/DataModel.java
@@ -84,8 +84,6 @@ public class DataModel {
 
     /**
      * Get all the {@code Patient}s currently registered to Baudit.
-     * <p>
-     * TODO: this getter should be narrowed down in scope/reach
      *
      * @return {@code PatientTreeSet}
      */

--- a/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Note: all {@code Patient}s and {@code CareProviders} are uniquely identified by their username within
  * the remote ElasticSearch.
  */
-public class RemoteModel {
+class RemoteModel {
     private static final String TAG = "RemoteModel";
     private static final String REMOTE_TEST_URL = "http://cmput301.softwareprocess.es:8080/cmput301f18t16test/";
 

--- a/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
@@ -52,7 +52,7 @@ public class RemoteModel {
      *
      * return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
      */
-    public static class uniqueID extends AsyncTask<String, Void, Boolean> {
+    public static class UniqueID extends AsyncTask<String, Void, Boolean> {
         @Override
         protected Boolean doInBackground(String... search_parameters) {
             JestDroidClient client = createBaseClient();
@@ -94,7 +94,7 @@ public class RemoteModel {
      *
      * return {@code Patient} corresponding to the username and password, or null if no such user is found
      */
-    public static class validateLogin extends AsyncTask<String, Void, Patient> {
+    public static class ValidateLogin extends AsyncTask<String, Void, Patient> {
         @Override
         protected Patient doInBackground(String... search_parameters) {
             JestDroidClient client = createBaseClient();

--- a/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
@@ -237,13 +237,13 @@ public class RemoteModel {
             for (Patient patient : patients) {
                 Index index = new Index.Builder(patient)
                         .index(PATIENT_INDEX)
-                        .id(patient.getUsername().getUsernameString()) // this sets the id...
+                        .id(patient.getUsername().toString()) // this sets the id...
                         .build();
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        assert patient.getUsername().getUsernameString().equals(result.getId());
-                        Log.d(TAG, "successfully added patient to remote: remoteID: " + patient.getUsername().getUsernameString());
+                        assert patient.getUsername().toString().equals(result.getId());
+                        Log.d(TAG, "successfully added patient to remote: remoteID: " + patient.getUsername().toString());
                     }
                 } catch (Exception e) {
                     Log.e(TAG, "failed to add patient to remote", e);
@@ -311,13 +311,13 @@ public class RemoteModel {
             for (CareProvider careProvider : careProviders) {
                 Index index = new Index.Builder(careProvider)
                         .index(CARE_PROVIDER_INDEX)
-                        .id(careProvider.getUsername().getUsernameString()) // this sets the id...
+                        .id(careProvider.getUsername().toString()) // this sets the id...
                         .build();
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        assert careProvider.getUsername().getUsernameString().equals(result.getId());
-                        Log.d(TAG, "successfully added care provider to remote: remoteID: " + careProvider.getUsername().getUsernameString());
+                        assert careProvider.getUsername().toString().equals(result.getId());
+                        Log.d(TAG, "successfully added care provider to remote: remoteID: " + careProvider.getUsername().toString());
                     }
                 } catch (Exception e) {
                     Log.e(TAG, "failed to add the care provider to remote", e);

--- a/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
@@ -57,29 +57,33 @@ public class RemoteModel {
             JestDroidClient client = createBaseClient();
             Log.d(TAG, "elastic search parameters: " + Arrays.toString(search_parameters));
             String query = "{\n" +
-                            "    \"query\": {\n" +
-                            "        \"ids\" : {\n" +
-                            "            \"type\" : \"patient\",\n" +
-                            "            \"values\" : [\"" + search_parameters[0] + "\"]\n" +
-                            "         }\n" +
-                            "     }\n" +
+                    "   \"query\": {\n" +
+                    "       \"bool\": {\n" +
+                    "           \"must\": [\n" +
+                    "                {\"match\": \n" +
+                    "                    {\"_id\" : \"" + search_parameters[0] + "\"} \n" +
+                    "                } \n" +
+                    "           ] \n" +
+                    "       } \n" +
+                    "   } \n" +
                             "}";
 
             Log.d(TAG, "search query:\n" + query);
             Search search = new Search.Builder(query)
+                    .addIndex(CARE_PROVIDER_INDEX)
                     .addIndex(PATIENT_INDEX)
                     .build();
             Log.d(TAG, "search json: " + search.toString());
-            List<Patient> patientList;
 
             try {
                 JestResult result = client.execute(search);
                 if (result.isSucceeded()) {
-                    patientList = result.getSourceAsObjectList(Patient.class);
-                    return (patientList.size() == 0);
+                    List<Account> accountList;
+                    accountList = result.getSourceAsObjectList(Account.class);
+                    return (accountList.size() == 0);
                 }
             } catch (Exception e) {
-                Log.e(TAG, "failed to get patient username from remote", e);
+                Log.e(TAG, "failed to validate account username from remote", e);
                 return false; // assume false on failure to avoid an unexpected state
             }
             return false;

--- a/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
+++ b/app/src/main/java/ca/klapstein/baudit/models/RemoteModel.java
@@ -50,12 +50,41 @@ public class RemoteModel {
      * <p>
      * TODO: implement
      *
-     * @param username {@code String}
      * @return {@code true} if the username {@code String} representation is not already taken, otherwise {@code false}
      */
-    static public boolean uniqueID(String username) {
-        // TODO: implement uniqueness checking of a userid given a string
-        return true;
+    public static class IsIdUnique extends AsyncTask<String, Void, Boolean> {
+        @Override
+        protected Boolean doInBackground(String... search_parameters) {
+            JestDroidClient client = createBaseClient();
+            Log.d(TAG, "elastic search parameters: " + Arrays.toString(search_parameters));
+            String query =
+                    "{\n" +
+                            "    \"query\": {\n" +
+                            "        \"ids\" : {\n" +
+                            "            \"type\" : \"patient\",\n" +
+                            "            \"values\" : [\"" + search_parameters[0] + "\"]\n" +
+                            "         }\n" +
+                            "     }\n" +
+                            "}";
+
+            Log.d(TAG, "search query:\n" + query);
+            Search search = new Search.Builder(query)
+                    .addIndex(PATIENT_INDEX)
+                    .build();
+            Log.d(TAG, "search json: " + search.toString());
+            List<Patient> patientList;
+
+            try {
+                JestResult result = client.execute(search);
+                if (result.isSucceeded()) {
+                    patientList = result.getSourceAsObjectList(Patient.class);
+                    return (patientList.size() != 0);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "failed to get care providers from remote", e);
+            }
+            return null;
+        }
     }
 
     /**

--- a/app/src/main/java/ca/klapstein/baudit/presenters/CreateAccountPresenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/CreateAccountPresenter.java
@@ -13,7 +13,6 @@ abstract public class CreateAccountPresenter<V extends CreateAccountView> extend
         super(view, context);
     }
 
-
     public boolean validateBaseAccount(String username, String email) {
         return true;
     }

--- a/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
@@ -18,8 +18,6 @@ import ca.klapstein.baudit.views.LogoutView;
 public class LoginPresenter extends Presenter<LoginView> {
     private static final String TAG = "LoginPresenter";
 
-    private Account account;
-
     public LoginPresenter(LoginView view, Context context) {
         super(view, context);
     }
@@ -30,7 +28,7 @@ public class LoginPresenter extends Presenter<LoginView> {
      * @param username {@code String}
      * @param password {@code String}
      */
-    public void onLoginButtonClicked(/*String type, */String username, String password) {
+    public void onLoginButtonClicked(String username, String password) {
         try {
             if (dataManager.validateLogin(new Username(username), new Password(password))) {
                 this.view.onLoginValidationSuccess();

--- a/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
@@ -2,6 +2,8 @@ package ca.klapstein.baudit.presenters;
 
 import android.content.Context;
 import ca.klapstein.baudit.data.Account;
+import ca.klapstein.baudit.data.Password;
+import ca.klapstein.baudit.data.Username;
 import ca.klapstein.baudit.views.LoginView;
 import ca.klapstein.baudit.views.LogoutView;
 
@@ -29,9 +31,13 @@ public class LoginPresenter extends Presenter<LoginView> {
      * @param password {@code String}
      */
     public void onLoginButtonClicked(/*String type, */String username, String password) {
-        if (dataManager.validateLogin(/*type, */username, password) != null) {
-            this.view.onLoginValidationSuccess();
-        } else {
+        try {
+            if (dataManager.validateLogin(new Username(username), new Password(password))) {
+                this.view.onLoginValidationSuccess();
+            } else {
+                this.view.onLoginValidationFailure();
+            }
+        } catch (IllegalArgumentException e) {
             this.view.onLoginValidationFailure();
         }
     }

--- a/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/LoginPresenter.java
@@ -28,8 +28,8 @@ public class LoginPresenter extends Presenter<LoginView> {
      * @param username {@code String}
      * @param password {@code String}
      */
-    public void onLoginButtonClicked(String username, String password) {
-        if (dataManager.validateLogin(username, password)) {
+    public void onLoginButtonClicked(/*String type, */String username, String password) {
+        if (dataManager.validateLogin(/*type, */username, password) != null) {
             this.view.onLoginValidationSuccess();
         } else {
             this.view.onLoginValidationFailure();

--- a/app/src/main/java/ca/klapstein/baudit/presenters/Presenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/Presenter.java
@@ -21,9 +21,4 @@ abstract public class Presenter<V extends View> {
         // TODO: pass context
         this.dataManager = new DataModel(context);
     }
-//
-//    /**
-//     * Hook to define behavior to be done when a Activity notifies that they have started.
-//     */
-//    abstract void notifyStart();
 }

--- a/app/src/test/java/ca/klapstein/baudit/data/PasswordTest.java
+++ b/app/src/test/java/ca/klapstein/baudit/data/PasswordTest.java
@@ -7,10 +7,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(Enclosed.class)
     public class PasswordTest {
@@ -44,14 +41,14 @@ import static org.junit.Assert.assertTrue;
         @Test
         public void testGetPassword() {
             Password password = new Password(input);
-            assertEquals(input, password.getPassword());
+            assertEquals(input, password.toString());
         }
 
         @Test
         public void testSetPassword() {
             Password password = new Password(input);
             password.setPassword("differentPassword");
-            assertEquals("differentPassword", password.getPassword());
+            assertEquals("differentPassword", password.toString());
         }
     }
 

--- a/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
+++ b/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
@@ -30,21 +30,21 @@ public class UsernameTest {
         public void testUsernameConstructor() {
             Username username = new Username(input);
             assertNotNull(username);
-            assertEquals(input, username.getUsernameString());
+            assertEquals(input, username.toString());
         }
 
         @Test
         public void testGetUsername() {
             Username username = new Username(input);
             assertNotNull(username);
-            assertEquals(input, username.getUsernameString());
+            assertEquals(input, username.toString());
         }
 
         @Test
         public void testSetUsername() {
             Username username = new Username(input);
-            username.setUsernameString(input);
-            assertEquals(input, username.getUsernameString());
+            username.setUsername(input);
+            assertEquals(input, username.toString());
         }
     }
 
@@ -65,19 +65,19 @@ public class UsernameTest {
         public void testUsernameConstructor() {
             Username username = new Username(input);
             assertNotNull(username);
-            assertEquals(input, username.getUsernameString());
+            assertEquals(input, username.toString());
         }
 
         @Test(expected = IllegalArgumentException.class)
         public void testSetUsername() {
             Username username = new Username("validuser");
-            username.setUsernameString(input);
-            assertEquals(input, username.getUsernameString());
+            username.setUsername(input);
+            assertEquals(input, username.toString());
         }
 
         @Test(expected = IllegalArgumentException.class)
         public void testUsernameConstructorInvalid() {
-            Username username = new Username(input);
+            new Username(input);
         }
     }
 }

--- a/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
+++ b/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
@@ -14,12 +14,13 @@ public class UsernameTest {
 // TODO: enable when a RemoteModel is implemented or mocked
     @RunWith(Parameterized.class)
     public static class ValidUserNameTest {
+
+        private String input;
+
         @Parameters(name = "{index}: valid({0})={1}")
         public static String[] validUserName() {
             return new String[]{"testUser", "testUser1", "@!516!@4!@$!2°▐"};
         }
-
-        private String input;
 
         public ValidUserNameTest(String input) {
             this.input = input;

--- a/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
+++ b/app/src/test/java/ca/klapstein/baudit/data/UsernameTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -11,40 +12,40 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(Enclosed.class)
 public class UsernameTest {
 // TODO: enable when a RemoteModel is implemented or mocked
-//    @RunWith(Parameterized.class)
-//    public static class ValidUserNameTest {
-//        @Parameterized.Parameters(name = "{index}: valid({0})={1}")
-//        public static String[] validUserName() {
-//            return new String[]{"testUser", "testUser1", "@!516!@4!@$!2°▐"};
-//        }
-//
-//        private String input;
-//
-//        public ValidUserNameTest(String input) {
-//            this.input = input;
-//        }
-//
-//        @Test
-//        public void testUsernameConstructor() {
-//            Username username = new Username(input);
-//            assertNotNull(username);
-//            assertEquals(input, username.getUsernameString());
-//        }
-//
-//        @Test
-//        public void testGetUsername() {
-//            Username username = new Username(input);
-//            assertNotNull(username);
-//            assertEquals(input, username.getUsernameString());
-//        }
-//
-//        @Test
-//        public void testSetUsername() {
-//            Username username = new Username(input);
-//            username.setUsernameString(input);
-//            assertEquals(input, username.getUsernameString());
-//        }
-//    }
+    @RunWith(Parameterized.class)
+    public static class ValidUserNameTest {
+        @Parameters(name = "{index}: valid({0})={1}")
+        public static String[] validUserName() {
+            return new String[]{"testUser", "testUser1", "@!516!@4!@$!2°▐"};
+        }
+
+        private String input;
+
+        public ValidUserNameTest(String input) {
+            this.input = input;
+        }
+
+        @Test
+        public void testUsernameConstructor() {
+            Username username = new Username(input);
+            assertNotNull(username);
+            assertEquals(input, username.getUsernameString());
+        }
+
+        @Test
+        public void testGetUsername() {
+            Username username = new Username(input);
+            assertNotNull(username);
+            assertEquals(input, username.getUsernameString());
+        }
+
+        @Test
+        public void testSetUsername() {
+            Username username = new Username(input);
+            username.setUsernameString(input);
+            assertEquals(input, username.getUsernameString());
+        }
+    }
 
     @RunWith(Parameterized.class)
     public static class InvalidUserNameTest {
@@ -54,7 +55,7 @@ public class UsernameTest {
             this.input = input;
         }
 
-        @Parameterized.Parameters(name = "{index}: invalid({0})={1}")
+        @Parameters(name = "{index}: invalid({0})={1}")
         public static String[] invalidUserName() {
             return new String[]{"short", "testUserThatIsWayTooLong", ""};
         }


### PR DESCRIPTION
Adding unique Id and login validation.

Also hooked this functionality into the `LoginPresenter` and `LoginCareProviderActivity` and `LoginPatientActivity`.

These tests are still abit finicky as they rely on the fact that our testing ElasticSearch remote contains the users `TESTPatient1` and `TESTCareProvider1` both with the password `foobar123`

Removed checks for a unique username in  `Username`