### PR TITLE
Fix assigning invalid patient account QR code

### DIFF
--- a/app/src/main/java/ca/klapstein/baudit/presenters/CareProviderHomePresenter.java
+++ b/app/src/main/java/ca/klapstein/baudit/presenters/CareProviderHomePresenter.java
@@ -37,7 +37,7 @@ public class CareProviderHomePresenter extends Presenter<CareProviderHomeView> {
             careProvider.getAssignedPatientTreeSet().add(dataManager.getPatient(new Username(username)));
             dataManager.commitCareProvider(careProvider);
             view.updateList();
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             Log.e(TAG, "failed to assign patient " + username, e);
             view.updateScanQRCodeError();
         }


### PR DESCRIPTION
Fixes crash that is caused by a care provider attempting to add a invalid Account QR code (i.e. not a patient account QR code).